### PR TITLE
Verify Read Permissions in viewfile

### DIFF
--- a/class.sphinxsearch.plugin.php
+++ b/class.sphinxsearch.plugin.php
@@ -240,6 +240,8 @@ class SphinxSearchPlugin extends Gdn_Plugin implements SplSubject {
                     }
                     if (isset($File) && !file_exists($File))
                         echo ('File does not exist here: ' . $File);
+                    elseif (!is_readable($File))
+                        echo ('File "' . $File . '" is not readable.');
                     else {
                         echo nl2br(file_get_contents($File));
                     }


### PR DESCRIPTION
Make sure we can actually read the file we are trying to read, if we can't print an error message instead of silently failing.
