### PR TITLE
Check the configuration before adding JS

### DIFF
--- a/class.sphinxsearch.plugin.php
+++ b/class.sphinxsearch.plugin.php
@@ -468,7 +468,9 @@ class SphinxSearchPlugin extends Gdn_Plugin implements SplSubject {
      * @param type $Args
      */
     public function PostController_BeforeFormInputs_Handler($Sender, $Args) {
+      if(C('Plugin.SphinxSearch.LimitRelatedThreadsPost', 0) != 0) {
         include_once(PATH_PLUGINS . DS . 'SphinxSearch' . DS . 'widgets' . DS . 'views' . DS . 'relatedpost.php');
+      }
     }
 
     /**


### PR DESCRIPTION
Completely disable related posts widget when limit set to zero. Closes #15
