### PR TITLE
Replace deprecated GetPermissions call for Vanilla 2.6+ compatibility

### DIFF
--- a/widgets/class.widget.main.php
+++ b/widgets/class.widget.main.php
@@ -91,7 +91,7 @@ class WidgetMain extends Widgets implements SplObserver {
             $Offset = 0;
 
         //Make sure results respect category permissions depending on user performing search
-        $Permissions = Gdn::Session()->GetPermissions(); // Get user permissions
+        $Permissions = Gdn::Session()->getPermissionsArray(); // Get user permissions
         $Permissions = $Permissions['Vanilla.Discussions.View']; // Only care about 'viewing' permissions
         $this->SphinxClient->SetFilter(SS_ATTR_CATPERMID, $Permissions);
 

--- a/widgets/class.widget.relateddiscussion.php
+++ b/widgets/class.widget.relateddiscussion.php
@@ -70,7 +70,7 @@ class WidgetRelatedDiscussion extends Widgets implements SplObserver {
             $Query = $this->FieldSearch($this->OperatorOrSearch($Thread), array(SS_FIELD_TITLE));
 
             //Make sure results respect category permissions depending on user performing search
-            $Permissions = Gdn::Session()->GetPermissions(); // Get user permissions
+            $Permissions = Gdn::Session()->getPermissionsArray(); // Get user permissions
             $Permissions = $Permissions['Vanilla.Discussions.View']; // Only care about 'viewing' permissions
             $this->SphinxClient->SetFilter(SS_ATTR_CATPERMID, $Permissions);
 

--- a/widgets/class.widget.relatedmain.php
+++ b/widgets/class.widget.relatedmain.php
@@ -39,7 +39,7 @@ class WidgetRelatedMain extends Widgets implements SplObserver {
             //echo $Query; die;
 
             //Make sure results respect category permissions depending on user performing search
-            $Permissions = Gdn::Session()->GetPermissions(); // Get user permissions
+            $Permissions = Gdn::Session()->getPermissionsArray(); // Get user permissions
             $Permissions = $Permissions['Vanilla.Discussions.View']; // Only care about 'viewing' permissions
             $this->SphinxClient->SetFilter(SS_ATTR_CATPERMID, $Permissions);
 

--- a/widgets/class.widget.relatedpost.php
+++ b/widgets/class.widget.relatedpost.php
@@ -35,7 +35,7 @@ class WidgetRelatedPost extends Widgets implements SplObserver {
             $Query = $this->FieldSearch($this->OperatorOrSearch($Thread), array(SS_FIELD_TITLE));
 
             //Make sure results respect category permissions depending on user performing search
-            $Permissions = Gdn::Session()->GetPermissions(); // Get user permissions
+            $Permissions = Gdn::Session()->getPermissionsArray(); // Get user permissions
             $Permissions = $Permissions['Vanilla.Discussions.View']; // Only care about 'viewing' permissions
             $this->SphinxClient->SetFilter(SS_ATTR_CATPERMID, $Permissions);
 


### PR DESCRIPTION
This is a minor update to replace the now-deprecated call to GetPermissions (returning an array) with a current equivalent call, GetPermissionsArray.